### PR TITLE
Replace ping with curl to improve rootless containers compatibility

### DIFF
--- a/root/teamspeak/sh/check_update.sh
+++ b/root/teamspeak/sh/check_update.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #Check internet connectivity
-if !(ping -q -c 1 -W 1 teamspeak.com > /dev/null)
+if !(curl -s --head --fail https://teamspeak.com > /dev/null)
 then
     echo "Internet connectivity check failed!"
     return

--- a/root/teamspeak/sh/check_update.sh
+++ b/root/teamspeak/sh/check_update.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #Check internet connectivity
-if !(curl -s --head --fail https://teamspeak.com > /dev/null)
+if !(curl --connect-timeout 1 -s --head --fail https://teamspeak.com > /dev/null)
 then
     echo "Internet connectivity check failed!"
     return

--- a/root/teamspeak/sh/update.sh
+++ b/root/teamspeak/sh/update.sh
@@ -32,7 +32,7 @@ create_version_file(){
 
 
 #Check internet connectivity
-if !(curl -s --head --fail https://teamspeak.com > /dev/null)
+if !(curl --connect-timeout 1 -s --head --fail https://teamspeak.com > /dev/null)
 then
     echo "Internet connectivity check failed! No update was done."
     return

--- a/root/teamspeak/sh/update.sh
+++ b/root/teamspeak/sh/update.sh
@@ -32,7 +32,7 @@ create_version_file(){
 
 
 #Check internet connectivity
-if !(ping -q -c 1 -W 1 teamspeak.com > /dev/null)
+if !(curl -s --head --fail https://teamspeak.com > /dev/null)
 then
     echo "Internet connectivity check failed! No update was done."
     return


### PR DESCRIPTION
When run under rootless container (e.g. podman), ping requires NET_RAW cap_add. This change removes this dependency.